### PR TITLE
新增替换特殊字段，修改so文件位置

### DIFF
--- a/115/api.go
+++ b/115/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gaoyb7/115drive-webdav/common"
 )
 
-const (
+var (
 	UserAgent       = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36 115Browser/23.9.3"
 	UserAgentForURL = "Mozilla/5.0; 115Desktop/2.0.1.7"
 

--- a/115/crypto.go
+++ b/115/crypto.go
@@ -7,8 +7,8 @@ import (
 	"unsafe"
 )
 
-//#cgo CFLAGS: -I.
-//#cgo LDFLAGS: -L. -lencode115
+//#cgo CFLAGS: -I${SRCDIR}
+//#cgo LDFLAGS: -L${SRCDIR} -lencode115
 //
 //#include "encode115.h"
 import "C"

--- a/115/types.go
+++ b/115/types.go
@@ -2,6 +2,8 @@ package _115
 
 import (
 	"encoding/json"
+	"github.com/gaoyb7/115drive-webdav/common/config"
+	"strings"
 	"time"
 )
 
@@ -120,7 +122,32 @@ type APILoginCheckResp struct {
 }
 
 func (f *FileInfo) GetName() string {
-	return f.Name
+	reName := f.Name
+	var s []string
+	c := config.Config.Replace
+	if c != "" {
+		if strings.Contains(c, "|") {
+			s = strings.Split(c, "|")
+		}
+		if s == nil {
+			o := strings.Split(c, "==")
+			if len(o) == 2 {
+				return strings.ReplaceAll(reName, o[0], o[1])
+			}
+			return reName
+		}
+		for _, r := range s {
+
+			o := strings.Split(r, "==")
+			if len(o) == 2 {
+				reName = strings.ReplaceAll(reName, o[0], o[1])
+			}
+
+		}
+
+	}
+	return reName
+
 }
 
 func (f *FileInfo) GetSize() int64 {

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ https://github.com/gaoyb7/115drive-webdav/releases
 ```
 服务启动成功后，用支持 WebDav 协议的客户端连接即可，不支持浏览器直接打开
 
+替换后缀请在config中替换 `replace`的内容 默认`"*==."`,多个`"a==b|c==d|x==y"`
+
 ## Docker 运行
 ```bash
 # 通过命令参数获取配置

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"github.com/gaoyb7/115drive-webdav/common/flag"
@@ -17,6 +16,7 @@ type config struct {
 	Port     int    `json:"port"`
 	User     string `json:"user"`
 	Password string `json:"pwd"`
+	Replace  string `json:"replace"`
 }
 
 var Config config
@@ -32,11 +32,12 @@ func init() {
 		Config.Port = flag.CliPort
 		Config.User = flag.CliUser
 		Config.Password = flag.CliPassword
+		Config.Replace = flag.Replace
 	}
 }
 
 func load(filename string) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		pwd, _ := os.Getwd()
 		logrus.WithField("pwd", pwd).WithField("filename", filename).Errorf("err: %v", err)

--- a/common/flag/flag.go
+++ b/common/flag/flag.go
@@ -13,6 +13,7 @@ var (
 	CliUser     string
 	CliPassword string
 	ConfigFile  string
+	Replace     string
 )
 
 func init() {
@@ -24,6 +25,7 @@ func init() {
 	flag.StringVar(&CliUser, "user", "user", "webdav auth username")
 	flag.StringVar(&CliPassword, "pwd", "123456", "webdav auth password")
 	flag.IntVar(&CliPort, "port", 8080, "webdav server port")
+	flag.StringVar(&Replace, "replace", "*==.", "replace special characters")
 }
 
 func init() {

--- a/config.json.example
+++ b/config.json.example
@@ -6,4 +6,5 @@
 	"port": 8081,
 	"user": "user",
 	"pwd": "123456"
+	"replace":"*==."
 }


### PR DESCRIPTION
不对的地方请大佬更正，
1.115/api.go中使用var 更加便于后期修改
2.115/crypto.go 中可以将so文件和编译文件同目录方便使用
3.115/types.go README.md  common/config/config.go  common/flag/flag.go config.json.example 用于对新增特殊字符串的替换。默认将小幸运的字符串替换掉。
